### PR TITLE
Bugfix/plugin_init_deprecated (#1)

### DIFF
--- a/octoprint_terminalresponse/__init__.py
+++ b/octoprint_terminalresponse/__init__.py
@@ -14,7 +14,7 @@ import octoprint.settings
 __plugin_name__ = "Terminal Response"
 __plugin_pythoncompat__ = ">=2.7,<4"
 
-def __plugin_init__():
+def __plugin_load__():
     global _plugin
     global __plugin_hooks__
 

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "octoprint_terminalresponse"
 plugin_name = "Terminal Response"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "0.1.3"
+plugin_version = "0.1.4"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module


### PR DESCRIPTION
replace deprecated `__plugin_init__` with `__plugin_load__` and bump version, resolves #5.

I also noticed that you haven't been creating releases in github. This is how your userbase gets update notifications, so make sure after you merge (or manually make these changes) that you generate a new release that matches the version number in setup.py.